### PR TITLE
Implement delete_versioned_model API (#602)

### DIFF
--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -131,13 +131,25 @@ bool add_model(redox::Redox& redis, const VersionedModelId& model_id,
                const std::string& model_data_path, int batch_size);
 
 /**
+ * Marks a model for deletion if it exists.
+ *
+ * \return Returns true if the model was present in the table
+ * and was successfully marked for deletion. Returns false if there was a
+ * problem
+ * or if the model was not in the table.
+ */
+bool mark_versioned_model_for_delete(redox::Redox& redis,
+                                     const VersionedModelId& model_id);
+
+/**
  * Deletes a model from the model table if it exists.
  *
  * \return Returns true if the model was present in the table
  * and was successfully deleted. Returns false if there was a problem
  * or if the model was not in the table.
  */
-bool delete_model(redox::Redox& redis, const VersionedModelId& model_id);
+bool delete_versioned_model(redox::Redox& redis,
+                            const VersionedModelId& model_id);
 
 /**
  * Looks up a model based on its model ID. This

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -89,10 +89,10 @@ TEST_F(RedisTest, AddModel) {
   ASSERT_TRUE(add_model(*redis_, model, InputType::Ints, labels, container_name,
                         model_path, DEFAULT_BATCH_SIZE));
   auto result = get_model(*redis_, model);
-  // The model table has 8 fields, so we expect
-  // to get back a map with 8 entries in it
+  // The model table has 9 fields, so we expect
+  // to get back a map with 9 entries in it
   // (see add_model() in redis.cpp for details on what the fields are).
-  EXPECT_EQ(result.size(), static_cast<size_t>(8));
+  EXPECT_EQ(result.size(), static_cast<size_t>(9));
   ASSERT_EQ(result["model_name"], model.get_name());
   ASSERT_EQ(result["model_version"], model.get_id());
   ASSERT_FLOAT_EQ(std::stof(result["load"]), 0.0);
@@ -264,8 +264,8 @@ TEST_F(RedisTest, DeleteModel) {
   ASSERT_TRUE(add_model(*redis_, model, InputType::Ints, labels, container_name,
                         model_path, DEFAULT_BATCH_SIZE));
   auto add_result = get_model(*redis_, model);
-  EXPECT_EQ(add_result.size(), static_cast<size_t>(8));
-  ASSERT_TRUE(delete_model(*redis_, model));
+  EXPECT_EQ(add_result.size(), static_cast<size_t>(9));
+  ASSERT_TRUE(delete_versioned_model(*redis_, model));
   auto delete_result = get_model(*redis_, model);
   EXPECT_EQ(delete_result.size(), static_cast<size_t>(0));
 }
@@ -452,7 +452,7 @@ TEST_F(RedisTest, SubscriptionDetectModelDelete) {
       });
   // give Redis some time to register the subscription
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  ASSERT_TRUE(delete_model(*redis_, model));
+  ASSERT_TRUE(delete_versioned_model(*redis_, model));
   std::unique_lock<std::mutex> l(notification_mutex);
   bool result = notification_recv.wait_for(l, std::chrono::milliseconds(1000),
                                            [&recv]() { return recv == true; });


### PR DESCRIPTION
* Implement delete_versioned_model API

* Remove the specified versions of the specified models from Clipper internal.
* Implemented `unregister_versioned_models` Clipper API in clipper_admin.

> Description
> -----------
> unregister_versioned_models(model_versions_dict)

> Parameters
> ----------
> model_versions_dict : dict(str, list(str))
>     For each entry in the dict, the key is a model name and the value is a list of model

> Raises
> ------
> :py:exc:`clipper.UnconnectedException`
>     versions. All replicas for each version of each model will be stopped.

* Implemented `delete_versioned_model` Management-Frontend API.

> API path
> --------
> POST /admin/delete_versioned_model

> Request schema
> --------------
> const std::string DELETE_VERSIONED_MODEL_JSON_SCHEMA = R"(
>   {
>    "model_name" := string,
>    "model_version" := string,
>   }
> )";

* Fix build error

* Fix unit test error

* Refactor TaskExecutor and fix bugs

* Enhance the clean-up steps about useless model container

* Add VersionedModelId to registered_containers_

* Fix threadpool's bug

* Call unregister_versioned_models() when stopped model containers

* Update clipper_admin_tests.py

* Fix TaskExecutor's bug

* Change _unregister_versioned_models API to private at clipper_admin

* Add three unittests to management_frontend_tests

* TestDeleteVersionedModelCorrect
* TestDeleteVersionedModelMissingField
* TestDeleteVersionedModelForNonexistentModel

* Fix build errors

* Add one unittest to management_frontend_tests

* TestDeleteVersionedModelForInvalidModel

* Fix TestDeleteVersionedModelCorrect unittest

* Fix build error

* Fix build error